### PR TITLE
add condition to allow tensorflow-macos instead of tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ matplotlib==3.5.2
 regex
 scipy
 h5py
-tensorflow==2.9.*
+tensorflow==2.9.* ; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.9.* ; sys_platform == 'darwin' and platform_machine == 'arm64'
 timm==0.6.*
 open_clip_torch==2.0.2
 git+https://github.com/openai/CLIP.git

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ requirements = [
                 'ftfy',
                 'numpy==1.22.*',
                 'pandas==1.4.*',
-                'tensorflow==2.9.*',
+                "tensorflow==2.9.* ; sys_platform != 'darwin' or platform_machine != 'arm64' ",
+                "tensorflow-macos==2.9.* ; sys_platform == 'darwin' and platform_machine == 'arm64' "
                 'torch==1.12.*',
                 'torchvision==0.13.*',
                 'open_clip_torch==2.0.*',


### PR DESCRIPTION
Although Lukas said to me in a recent discussion that all contributors use Macs, you must have all solved the tensorflow requirements issue that I and a few others have faced when trying to install THINGSvision on a Macbook. I have to get around this by cloning the repo and manually editing `setup.py` to allow for `tensorflow-macos` instead of plain `tensorflow` and running `python setup.py install` manually. 

This PR adds conditions to both `requirements.txt` and `setup.py` to reflect conditional dependency specification (_à la_ [PEP508](https://peps.python.org/pep-0508/)) based on the OS (so the installation doesn't fail if the user has a sufficient version of `tensorflow-macos`).

This would make it easier for me to keep up to date with the fast-moving pace of this library and hopefully for others who might struggle with the same issues I've faced.
