### PR TITLE
Update docs and add unittests

### DIFF
--- a/build/lib/tests/extractor/test_transformations.py
+++ b/build/lib/tests/extractor/test_transformations.py
@@ -1,0 +1,26 @@
+import unittest
+
+import tensorflow as tf
+import tests.helper as helper
+from torchvision import transforms as T
+
+
+class ModelTransformationsTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        helper.create_test_images()
+
+    def test_transformations_cnn(self):
+        model_name = "vgg16_bn"
+        extractor, _, _ = helper.create_extractor_and_dataloader(
+            model_name, pretrained=False, source="torchvision"
+        )
+        transforms = extractor.get_transformations()
+        self.assertTrue(isinstance(transforms, T.Compose))
+
+        model_name = "VGG16"
+        extractor, _, _ = helper.create_extractor_and_dataloader(
+            model_name, pretrained=False, source="keras"
+        )
+        transforms = extractor.get_transformations()
+        self.assertTrue(isinstance(transforms, tf.keras.Sequential))

--- a/docs/AvailableModels.md
+++ b/docs/AvailableModels.md
@@ -75,9 +75,13 @@ If you use `pretrained=True`, the model will be pretrained according to the mode
 * PIRL (`pirl-rn50`) 
 * BarlowTwins (`barlowtwins-rn50`)
 * VicReg (`vicreg-rn50`)
+* DINO (`dino-rn50`)
 
 All models have the ResNet50 architecture and are pretrained on ImageNet-1K. 
 Here, the model name describes the pre-training method, instead of the model architecture.
+
+DINO models are available in ViT (Vision Transformer) and XCiT (Cross-Covariance Image Transformer) variants. For ViT models trained using DINO, the following models are available: `dino-vit-small-p8`, `dino-vit-small-p16`, `dino-vit-big-p8`, `dino-vit-p16`, where the trailing number describes the image patch resolution in the ViT (i.e. either 8x8 or 16x16). For the XCiT models, we have `dino-xcit-small-12-p16`, `dino-xcit-small-12-p8`, `dino-xcit-medium-24-p16`, `dino-xcit-medium-24-p8`, where the penultimate number represents model depth (12 = small, 24 = medium).
+
 
 Example:
 ```python

--- a/tests/extractor/test_transformations.py
+++ b/tests/extractor/test_transformations.py
@@ -22,6 +22,7 @@ class ModelTransformationsTestCase(unittest.TestCase):
         extractor, _, _ = helper.create_extractor_and_dataloader(
             model_name, pretrained=False, source="keras"
         )
+        transforms = extractor.get_transformations()
         self.assertTrue(isinstance(transforms, tf.keras.Sequential))
 
     def test_transformations_transformer(self):

--- a/tests/extractor/test_transformations.py
+++ b/tests/extractor/test_transformations.py
@@ -22,5 +22,18 @@ class ModelTransformationsTestCase(unittest.TestCase):
         extractor, _, _ = helper.create_extractor_and_dataloader(
             model_name, pretrained=False, source="keras"
         )
+
+    def test_transformations_transformer(self):
+        model_name = "dino-xcit-medium-24-p16"
+        extractor, _, _ = helper.create_extractor_and_dataloader(
+            model_name, pretrained=False, source="ssl"
+        )
         transforms = extractor.get_transformations()
-        self.assertTrue(isinstance(transforms, tf.keras.Sequential))
+        self.assertTrue(isinstance(transforms, T.Compose))
+        
+        model_name = "dino-vit-small-p8"
+        extractor, _, _ = helper.create_extractor_and_dataloader(
+            model_name, pretrained=False, source="ssl"
+        )
+        transforms = extractor.get_transformations()
+        self.assertTrue(isinstance(transforms, T.Compose))

--- a/tests/extractor/test_transformations.py
+++ b/tests/extractor/test_transformations.py
@@ -22,6 +22,7 @@ class ModelTransformationsTestCase(unittest.TestCase):
         extractor, _, _ = helper.create_extractor_and_dataloader(
             model_name, pretrained=False, source="keras"
         )
+        self.assertTrue(isinstance(transforms, tf.keras.Sequential))
 
     def test_transformations_transformer(self):
         model_name = "dino-xcit-medium-24-p16"

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -92,7 +92,8 @@ MODEL_AND_MODULE_NAMES = {
     'swav-rn50': SSL_RN50_DEFAULT_CONFIG,
     'pirl-rn50': SSL_RN50_DEFAULT_CONFIG,
     'barlowtwins-rn50': SSL_RN50_DEFAULT_CONFIG,
-    'vicreg-rn50': SSL_RN50_DEFAULT_CONFIG
+    'vicreg-rn50': SSL_RN50_DEFAULT_CONFIG,
+    'dino-rn50' : SSL_RN50_DEFAULT_CONFIG
 }
 
 

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -217,22 +217,22 @@ class SSLExtractor(PyTorchExtractor):
             "arch": "resnet50",
             "type": "hub",
         },
-        "dino-vits16": {
+        "dino-vit-small-p16": {
             "repository": "facebookresearch/dino:main",
             "arch": "dino_vits16",
             "type": "hub",
         },
-         "dino-vits8": {
+         "dino-vit-small-p8": {
             "repository": "facebookresearch/dino:main",
             "arch": "dino_vits8",
             "type": "hub",
         },
-        "dino-vitb16": {
+        "dino-vit-big-p16": {
             "repository": "facebookresearch/dino:main",
             "arch": "dino_vitb16",
             "type": "hub",
         },
-        "dino-vitb8": {
+        "dino-vit-big-p8": {
             "repository": "facebookresearch/dino:main",
             "arch": "dino_vitb8",
             "type": "hub",
@@ -257,7 +257,7 @@ class SSLExtractor(PyTorchExtractor):
             "arch": "dino_xcit_medium_24_p8",
             "type": "hub",
         },
-        "dino-resnet50": {
+        "dino-rn50": {
             "repository": "facebookresearch/dino:main",
             "arch": "dino_resnet50",
             "type": "hub",


### PR DESCRIPTION
As requested. Update docs to reflect addition of new DINO models.

Added unittests in `test_transformations.py` for two of the models.

I then amended the naming conventions a bit in `extractors.py` because there was a discrepancy between model size and image patch resolution between the ViT and XCiT models. It makes it easier to follow a pattern, i.e. by specifying patch resolution with `p` prior to the number in the ViT numbers (which didn't do it already, but XCiT models did). This steps away from the naming conventions used in the source material, so I'm not sure it's the best idea but from a user perspective, I think it adds more clarity. However, might slip up someone who knows the original conventions. Basically, `ViT-S/16` -> `(dino)-vit-small-p16`. I'm totally open to amending this to be more in line with naming conventions used elsewhere, if others disagree it is a helpful change. No problem to change it back again :) 

Also, prior update had named the ResNet version of DINO (`dino-resnet50`) but I changed it to `dino-rn50` to be in line with the naming convention of the other ResNet models in `thingsvision`. 