### PR TITLE
Fix clip not working in Pytorch colab

### DIFF
--- a/notebooks/pytorch.ipynb
+++ b/notebooks/pytorch.ipynb
@@ -32,7 +32,8 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade thingsvision"
+    "!pip install --upgrade thingsvision\n",
+    "!pip install git+https://github.com/openai/CLIP.git"
    ]
   },
   {


### PR DESCRIPTION
We were missing the installation of the clip dependency in our PyTorch colab notebook, this adds it in.