### PR TITLE
Memory leak fix when only extracting cls token

### DIFF
--- a/thingsvision/core/extraction/torch.py
+++ b/thingsvision/core/extraction/torch.py
@@ -109,7 +109,7 @@ class PyTorchExtractor(BaseExtractor):
         act = self.activations[module_name]
         if hasattr(self, "extract_cls_token"):
             # we are only interested in the representations of the first token, i.e., [cls] token
-            act = act[:, 0, :]
+            act = act[:, 0, :].clone()
         if flatten_acts:
             if self.model_name.lower().startswith("clip"):
                 act = self.flatten_acts(act, batch, module_name)


### PR DESCRIPTION
* Fixes memory leak when extracting the cls token of a model.
* We need an additional clone when we create a view on the tensor.