### PR TITLE
adding the other versions of dreamsim

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ features = extractor.extract_features(
     batches=batches,
     module_name=module_name,
     flatten_acts=True,
-    output_type="ndarray", # or "tensor" (only applicable to PyTorch models of which CLIP is one!)
+    output_type="ndarray", # or "tensor" (only applicable to PyTorch models of which CLIP and DINO are ones!)
 )
 
 save_features(features, out_path='path/to/features', file_format='npy') # file_format can be set to "npy", "txt", "mat", "pt", or "hdf5"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Neural networks come from different sources. With `thingsvision`, you can extrac
 - a few custom models (Alexnet, VGG-16, Resnet50, and Inception_v3) trained on [Ecoset](https://www.pnas.org/doi/10.1073/pnas.2011417118) rather than ImageNet and one Alexnet model pretrained on ImageNet and fine-tuned on [SalObjSub](https://cs-people.bu.edu/jmzhang/sos.html)<br>
 - each of the many [CORnet](https://github.com/dicarlolab/CORnet) versions
 - [Harmonization](https://arxiv.org/abs/2211.04533) models (see [Harmonization repo](https://github.com/serre-lab/harmonization)). The default variant is `ViT_B16`. Other available models are `ResNet50`, `VGG16`, `EfficientNetB0`, `tiny_ConvNeXT`, `tiny_MaxViT`, and `LeViT_small`<br> 
-- [DreamSim](https://dreamsim-nights.github.io/) models  (see [DreamSim repo](https://github.com/ssundaram21/dreamsim)). The default variant is `open_clip_vitb32`. Other available models are `clip_vitb32`. See the [docs](https://vicco-group.github.io/thingsvision/AvailableModels.html#dreamsim) for more information
+- [DreamSim](https://dreamsim-nights.github.io/) models  (see [DreamSim repo](https://github.com/ssundaram21/dreamsim)). The default variant is `open_clip_vitb32`. Other available models are `clip_vitb32`, `dino_vitb16`, and an `ensemble`. See the [docs](https://vicco-group.github.io/thingsvision/AvailableModels.html#dreamsim) for more information
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/docs/AvailableModels.md
+++ b/docs/AvailableModels.md
@@ -312,7 +312,7 @@ extractor = get_extractor(
 ```
 
 ### DreamSim
-We provide the [DreamSim](https://dreamsim-nights.github.io/) model from the original [DreamSim repo](https://github.com/ssundaram21/dreamsim). To extract features, first install the `dreamsim` package with the following `pip` command 
+In `thingsvision` you can extract representations from [DreamSim](https://dreamsim-nights.github.io/). See the official [DreamSim repo](https://github.com/ssundaram21/dreamsim) for more information. To extract features, install the `dreamsim` package with the following `pip` command (ideally, into your `thingsvision` environment):
 
 ```bash
  $ pip install dreamsim==0.1.2
@@ -321,7 +321,7 @@ We provide the [DreamSim](https://dreamsim-nights.github.io/) model from the ori
 The base model name is:
 - `DreamSim`
 
-We provide four `DreamSim` architectures: `clip_vitb32`, `open_clip_vitb32`, `dino_vitb16`, and an `ensemble`. This can be specified using the `model_parameters` argument. For instance, to get the OpenCLIP variant of DreamSim you would do the following:
+We provide four `DreamSim` models: `clip_vitb32`, `open_clip_vitb32`, `dino_vitb16`, and a DreamSim `ensemble`. Specify this using the `model_parameters` argument. For instance, to get the OpenCLIP variant of DreamSim you want to do the following:
 
 ```python
 import torch
@@ -343,4 +343,5 @@ extractor = get_extractor(
   model_parameters=model_parameters
 )
 ```
-To load the CLIP ViT-B/32 version of DreamSim, pass `'clip_vitb32'` to the `variant` parameter instead. Caution (!): for the DreamSim `ensemble` features can only be extracted from the `model.mlp` module. We are working on a version that allows feature extraction from the `model` block.
+
+To load the CLIP ViT-B/32 version of DreamSim, pass `'clip_vitb32'` to the `variant` parameter instead. Caution (!): for the DreamSim `ensemble` features can only be extracted from the `model.mlp` module and not for the `model` block. We are currently working on a version that allows feature extraction from the `model` block. Please be patient until then.

--- a/docs/AvailableModels.md
+++ b/docs/AvailableModels.md
@@ -216,12 +216,12 @@ extractor = get_extractor(
 
 ### Official CLIP and OpenCLIP
 
-We provide models trained using [CLIP](https://arxiv.org/abs/2103.00020), both from the official repository and from [OpenCLIP](https://github.com/mlfoundations/open_clip). Available `model_name`s are:
+We provide [CLIP](https://arxiv.org/abs/2103.00020) models from the official CLIP repo and from [OpenCLIP](https://github.com/mlfoundations/open_clip). Available `model_name`'s are:
 
 - `clip`
 - `OpenClip`
 
-Both provide multiple model architectures and, in the case of OpenCLIP also multiple training datasets, which can be specified using the `model_parameters` argument. For example, if you want to get a `ViT-B/32` model from official CLIP, you would do the following:
+Both provide multiple model architectures and, in the case of OpenCLIP also different training datasets, which can both be specified using the `model_parameters` argument. For example, if you want to get a `ViT-B/32` model from the official CLIP repo (trained on WIT), you would do the following:
 
 ```python
 import torch
@@ -272,14 +272,14 @@ For a list of all available architectures and datasets, please refer to the [Ope
 
 ### Harmonization
 
-If you want to extract features for [harmonized models](https://vicco-group.github.io/thingsvision/AvailableModels.html#harmonization) from the [Harmonization repo](https://github.com/serre-lab/harmonization), you have to additionally run the following `pip` command in your `thingsvision` environment (FYI: as of now, this seems to be working smoothly on Ubuntu only but not on macOS),
+If you want to extract features for [harmonized models](https://vicco-group.github.io/thingsvision/AvailableModels.html#harmonization) from the [Harmonization repo](https://github.com/serre-lab/harmonization), you have to run the following `pip` command in your `thingsvision` environment (FYI: as of now, this seems to be working smoothly only on Ubuntu but not on macOS),
 
 ```bash
 $ pip install git+https://github.com/serre-lab/Harmonization.git
 $ pip install keras-cv-attention-models>=1.3.5
 ```
 
-The following models from the [Harmonization repo](https://github.com/serre-lab/harmonization) are available:
+The following models from [here](https://github.com/serre-lab/harmonization) are available for feature extraction:
 
 - `ViT_B16`
 - `ResNet50`
@@ -288,6 +288,7 @@ The following models from the [Harmonization repo](https://github.com/serre-lab/
 - `tiny_ConvNeXT`
 - `tiny_MaxViT`
 - `LeViT_small`
+
 
 Example:
 
@@ -310,6 +311,7 @@ extractor = get_extractor(
   model_parameters=model_parameters
 )
 ```
+
 
 ### DreamSim
 In `thingsvision` you can extract representations from [DreamSim](https://dreamsim-nights.github.io/). See the official [DreamSim repo](https://github.com/ssundaram21/dreamsim) for more information. To extract features, install the `dreamsim` package with the following `pip` command (ideally, into your `thingsvision` environment):

--- a/docs/AvailableModels.md
+++ b/docs/AvailableModels.md
@@ -318,16 +318,17 @@ We provide the [DreamSim](https://dreamsim-nights.github.io/) model from the ori
  $ pip install dreamsim==0.1.2
 ```
 
-The model name is:
+The base model name is:
 - `DreamSim`
 
-We provide two `DreamSim` architectures: CLIP ViT-B/32 and OpenCLIP ViT-B/32. This can be specified using the `model_parameters` argument. For instance, to get the OpenCLIP variant of DreamSim you would do the following:
+We provide four `DreamSim` architectures: `clip_vitb32`, `open_clip_vitb32`, `dino_vitb16`, and an `ensemble`. This can be specified using the `model_parameters` argument. For instance, to get the OpenCLIP variant of DreamSim you would do the following:
 
 ```python
 import torch
 from thingsvision import get_extractor
 
 model_name = 'DreamSim'
+module_name = 'model.mlp'
 source = 'custom'
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 model_parameters = {
@@ -342,4 +343,4 @@ extractor = get_extractor(
   model_parameters=model_parameters
 )
 ```
-To load the CLIP ViT-B/32 variant, pass `'clip_vitb32'` to the `variant` parameter instead.
+To load the CLIP ViT-B/32 version of DreamSim, pass `'clip_vitb32'` to the `variant` parameter instead. Caution (!): for the DreamSim `ensemble` features can only be extracted from the `model.mlp` module. We are working on a version that allows feature extraction from the `model` block.

--- a/docs/AvailableModels.md
+++ b/docs/AvailableModels.md
@@ -346,4 +346,4 @@ extractor = get_extractor(
 )
 ```
 
-To load the CLIP ViT-B/32 version of DreamSim, pass `'clip_vitb32'` to the `variant` parameter instead. Caution (!): for the DreamSim `ensemble` features can only be extracted from the `model.mlp` module and not for the `model` block. We are currently working on a version that allows feature extraction from the `model` block. Please be patient until then.
+To load the CLIP ViT-B/32 version of DreamSim, pass `'clip_vitb32'` to the `variant` parameter instead. Caution (!): for the DreamSim `dino_vitb16` and `ensemble` features can only be extracted from the `model.mlp` module and not for the `model` block. We are currently working on a version that allows feature extraction from the `model` block. Please be patient until then.

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -220,6 +220,21 @@ MODEL_AND_MODULE_NAMES = {
         "source": "custom",
         "kwargs": {"variant": "open_clip_vitb32"},
     },
+        "DreamSim_mlp_dino_vitb16": {
+        "model_name": "DreamSim",
+        "modules": ["model.mlp"],
+        "pretrained": True,
+        "source": "custom",
+        "kwargs": {"variant": "dino_vitb16"},
+    },
+        "DreamSim_mlp_ensemble": {
+        "model_name": "DreamSim",
+        "modules": ["model.mlp"],
+        "pretrained": True,
+        "source": "custom",
+        "kwargs": {"variant": "ensemble"},
+    },
+}
 }
 
 FILE_FORMATS = ["hdf5", "npy", "mat", "pt", "txt"]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -220,21 +220,20 @@ MODEL_AND_MODULE_NAMES = {
         "source": "custom",
         "kwargs": {"variant": "open_clip_vitb32"},
     },
-        "DreamSim_mlp_dino_vitb16": {
+    "DreamSim_mlp_dino_vitb16": {
         "model_name": "DreamSim",
         "modules": ["model.mlp"],
         "pretrained": True,
         "source": "custom",
         "kwargs": {"variant": "dino_vitb16"},
     },
-        "DreamSim_mlp_ensemble": {
+    "DreamSim_mlp_ensemble": {
         "model_name": "DreamSim",
         "modules": ["model.mlp"],
         "pretrained": True,
         "source": "custom",
         "kwargs": {"variant": "ensemble"},
     },
-}
 }
 
 FILE_FORMATS = ["hdf5", "npy", "mat", "pt", "txt"]

--- a/thingsvision/custom_models/dreamsim/dreamsim.py
+++ b/thingsvision/custom_models/dreamsim/dreamsim.py
@@ -18,7 +18,7 @@ class DreamSimModel(nn.Module):
         :param model_type: either clip_vitb32 or open_clip_vitb32
         """
         super().__init__()
-        if model_type not in ["clip_vitb32", "open_clip_vitb32"]:
+        if model_type not in ["clip_vitb32", "open_clip_vitb32", "dino_vitb16", "ensemble"]:
             raise ValueError(f"Model type {model_type} not supported")
 
         self.model_type = model_type


### PR DESCRIPTION
This PR adds two new DreamSim models to `thingsvision`: `dino_vitb16` and a DreamSim `ensemble`. 