### PR TITLE
Fixed TorchvisionExtractor model_parameters

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -30,6 +30,13 @@ MODEL_AND_MODULE_NAMES = {
         "pretrained": False,
         "source": "torchvision",
     },
+    "vit_b_16": {
+        "model_name": "vit_b_16",
+        "modules": ["encoder.ln"],
+        "pretrained": True,
+        "source": "torchvision",
+        "kwargs": {"extract_cls_token": True, "weights": "DEFAULT"}
+    },
     # Hardcoded models
     "cornet_r": {
         "model_name": "cornet_r",

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -50,7 +50,7 @@ class TorchvisionExtractor(PyTorchExtractor):
             preprocess: Optional[Callable] = None,
     ) -> None:
         model_parameters = (
-            model_parameters if model_parameters else {"weights": "DEFAULT"},
+            model_parameters if model_parameters else {"weights": "DEFAULT"}
         )
         super().__init__(
             model_name=model_name,
@@ -73,7 +73,7 @@ class TorchvisionExtractor(PyTorchExtractor):
             )
         weights = getattr(
             getattr(torchvision.models, f"{weights_name}"),
-            self.model_parameters[0]["weights"],
+            self.model_parameters["weights"],
         )
         return weights
 


### PR DESCRIPTION
Made `model_parameters` in `TorchvisionExtractor` a `dict` instead of a `tuple` of `dict`. Previously, `extract_cls_token` did not work for torchvision models, as [line 36](https://github.com/ViCCo-Group/thingsvision/blob/107d317f4277e7414f259ed0b32186c68b105e9c/thingsvision/core/extraction/torch.py#L36) in `torch.py` would prevent the creation of the `extract_cls_token` attribute when a `tuple` was passed as `model_parameters` from `TorchvisionExtractor`.