### PR TITLE
Small fix for the show-model CLI functionality

### DIFF
--- a/thingsvision/thingsvision.py
+++ b/thingsvision/thingsvision.py
@@ -45,6 +45,12 @@ def get_parsers():
         help="""Device to use for the extractor. Options are 'cpu', 'cuda', or 'cuda:x', 
                 where x is the GPU index. (default: cuda)""",
     )
+    common_parser.add_argument(
+        "--model-parameters",
+        type=str,
+        default=None,
+        help="For CLIP, OpenCLIP, DreamSIM, and DINO models a model_parameters dictionary has to be defined. (default: None)",
+    )
 
     subparsers = parent_parser.add_subparsers(
         title="Subcommands",
@@ -92,12 +98,6 @@ def get_parsers():
     )
     parser_extract.add_argument(
         "--flatten-acts", action="store_true", help="Flatten activations before saving them to disk."
-    )
-    parser_extract.add_argument(
-        "--model-parameters",
-        type=str,
-        default=None,
-        help="For CLIP, OpenCLIP, DreamSIM, and DINO models a model_parameters dictionary has to be defined. (default: None)",
     )
     parser_extract.add_argument(
         "--module-name",
@@ -159,7 +159,7 @@ def main():
     )
 
     if args.command == "show-model":
-        extractor.show_model()
+        print(extractor.show_model())
         sys.exit(1)
 
     if args.command == "extract-features":


### PR DESCRIPTION
I've moved the --model-parameters argument into the common parser because the get_extractor function requires it. Without this, it wasn't possible to instantiate an extractor, even if we just wanted to show the model.

Also, I've added a `print` function around the `show_model` call because those methods return strings. One alternative to this would be to make all the `show_model` calls call `print` and change the method signatures to return `None` instead of `str`. This may be more faithful to the name of the function.

This should address #162 .