### PR TITLE
Bug fix for the extract-features CLI functionality

### DIFF
--- a/thingsvision/thingsvision.py
+++ b/thingsvision/thingsvision.py
@@ -170,7 +170,7 @@ def main():
             transforms=extractor.get_transformations(),
         )
         batches = DataLoader(
-            dataset=dataset, batch_size=args.batch_size, backend=extractor.backend
+            dataset=dataset, batch_size=args.batch_size, backend=extractor.get_backend()
         )
 
         features = extractor.extract_features(


### PR DESCRIPTION
For the extract-features CLI option, there was a reference to an attribute that doesn't exist in the extractor. Instead the `get_backend` function needed to be called.