### PR TITLE
Adaption to timm 0.9.x naming scheme

### DIFF
--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -134,7 +134,7 @@ class TimmExtractor(PyTorchExtractor):
 
     def load_model_from_source(self) -> None:
         """Load a (pretrained) neural network model from <timm>."""
-        if self.model_name in timm.list_models():
+        if self.model_name in timm.list_models() or self.model_name.split(".")[0] in timm.list_models():
             self.model = timm.create_model(self.model_name, pretrained=self.pretrained)
         else:
             raise ValueError(

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -134,7 +134,7 @@ class TimmExtractor(PyTorchExtractor):
 
     def load_model_from_source(self) -> None:
         """Load a (pretrained) neural network model from <timm>."""
-        if self.model_name in timm.list_models() or self.model_name.split(".")[0] in timm.list_models():
+        if self.model_name.split(".")[0] in timm.list_models():
             self.model = timm.create_model(self.model_name, pretrained=self.pretrained)
         else:
             raise ValueError(


### PR DESCRIPTION
In `timm 0.9.x`, the model naming scheme has changed, e.g. `vit_base_patch16_224_in21k` -> `vit_base_patch16_224.augreg_in21k` (the datasets are now separated by a '.'), but the part after '.' is omitted in `timm.list_models()`.  The change of the if-statement is a minimal change that allows for compatibility to both versions of `timm`.