### PR TITLE
Removes separate VISSL caching and adds file_name to torch.hub.load_state_dict_from_url everywhere

### DIFF
--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -353,7 +353,8 @@ class SSLExtractor(PyTorchExtractor):
     def _load_vissl_state_dict(self, model_url: str, unique_model_filename: str):
         """
         Downloads the model in vissl format, converts it to torchvision format and
-        saves it under output_model_filepath.
+        caches it under the unique_model_filename. Therefore, this file_name should be unique
+        per url. Otherwise, the wrong cached variant is loaded.
         """
         model = load_state_dict_from_url(model_url,
                                          map_location=torch.device("cpu"),
@@ -394,7 +395,7 @@ class SSLExtractor(PyTorchExtractor):
         if self.model_name in SSLExtractor.MODELS:
 
             # unique model id name for all models
-            unique_model_filename = f'thingsvision_ssl_v0_{self.model_name}'
+            unique_model_filename = f'thingsvision_ssl_v0_{self.model_name}.pth'
 
             # defines how the model should be loaded
             model_config = SSLExtractor.MODELS[self.model_name]

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -470,6 +470,7 @@ class SSLExtractor(PyTorchExtractor):
                 # load and cache state_dict
                 state_dict = torch.hub.load_state_dict_from_url(
                     model_config["checkpoint_url"],
+                    map_location=torch.device("cpu"),
                     # IMPORTANT that this is unique as it will be used for caching
                     file_name=unique_model_filename
                 )

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -429,6 +429,7 @@ class SSLExtractor(PyTorchExtractor):
                         raise ValueError(f"\n{self.model_name} is not available.\n")
                     state_dict = torch.hub.load_state_dict_from_url(
                         model_config["checkpoint_url"],
+                        map_location=torch.device("cpu"),
                         # This is used to cache the file
                         file_name=unique_model_filename
                     )
@@ -445,6 +446,7 @@ class SSLExtractor(PyTorchExtractor):
                         raise ValueError(f"\n{self.model_name} is not available.\n")
                     state_dict = torch.hub.load_state_dict_from_url(
                         model_config["checkpoint_url"],
+                        map_location=torch.device("cpu"),
                         file_name=unique_model_filename
                     )
                     checkpoint_model = state_dict["model"]


### PR DESCRIPTION
This PR fixes further issues with `torch.hub.load_state_dict_from_url`

* In every call to that function, the filename attribute is now set to avoid any unwanted caching.
* The additional caching of vissl models is now removed (previously the assumption was that `torch.hub.load_state_dict_from_url` does not perform any caching)
* The issue also affected loading the `barlowtwins` and `vicreg` models as in their respective `hubconf.py` also does not set the `filename` attribute and the filename in the url was the same. (e.g. https://github.com/facebookresearch/barlowtwins/blob/main/hubconf.py). These models are now directly loaded from the respective url while providing the `filename` attribute in the load function.
