### PR TITLE
fix scaling of RGBs for tensorflow

### DIFF
--- a/thingsvision/utils/data/dataset.py
+++ b/thingsvision/utils/data/dataset.py
@@ -128,7 +128,7 @@ class ImageDataset:
         if self.backend == "pt":
             img = self.transforms(img)
         elif self.backend == "tf":
-            img = tf.keras.preprocessing.image.img_to_array(img)
+            img = tf.keras.preprocessing.image.img_to_array(img) / 255.0 # the transforms don't scale RGB values, so we must do it manually
             img = self.transforms(img)
         else:
             raise ValueError(


### PR DESCRIPTION
Hi,

I've noticed that when using tensorflow models, the RGB values don't get scaled between 0 and 1. I believe `ToTensor` in `torchvision.transforms` handles this, but there is no such operation in the tf transforms that are defined. I created a minimal example of this issue [here](https://github.com/candemircan/harmonizer_thingsvision_check) where extracting features directly from the Harmonized models vs. using thingsvision yields different results.

For ImageDataset, I've added the scaling for the tf backend to fix this. Let me know if there is something I'm missing.

Best wishes,
Can