### PR TITLE
fix scaling of RGBs for tensorflow/keras

### DIFF
--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -238,7 +238,7 @@ class KerasExtractor(TensorFlowExtractor):
         ]
         # Try each pattern
         for pattern, preproc_val in patterns:
-            if re.match(pattern, model_name):
+            if re.search(pattern, model_name):
                 return preproc_val
                 
         # If no match is found, print a warning message

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -242,7 +242,7 @@ class KerasExtractor(TensorFlowExtractor):
                 return preproc_val
                 
         # If no match is found, print a warning message
-        warnings.warn(f"No preprocessing function found for model {model_name}, so falling back to default preprocessing.\nOften, models that come from Keras Applications have their own preprocessing functions, therefore this may create inaccurate results. If you need to manually specify a preprocessing function, please do so under the `transforms` argument when creating your DataSet")
+        warnings.warn(f"No preprocessing function found for model {model_name}, so falling back to default preprocessing.\nOften, models that come from Keras Applications have their own preprocessing functions.\nThus, this may create inaccurate results. If you need to manually specify a preprocessing function, please do so under the `transforms` argument when creating your Dataset")
         return None
 
 

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -213,7 +213,7 @@ class KerasExtractor(TensorFlowExtractor):
     @staticmethod
     def get_preproc_fun(preproc_fun_name: str) -> Callable:
         """Get the preprocessing function associated with a specific model."""
-        return getattr(getattr(tensorflow_models, preproc_fun_name), "preprocess_input"))
+        return getattr(getattr(tensorflow_models, preproc_fun_name), "preprocess_input")
 
     
     def get_keras_preprocessing(self, model_name:str) -> Union[str, None]:

--- a/thingsvision/core/extraction/extractors.py
+++ b/thingsvision/core/extraction/extractors.py
@@ -199,10 +199,10 @@ class KerasExtractor(TensorFlowExtractor):
             self.model = model(weights=weights)
             preproc_fun_name = self.get_keras_preprocessing(self.model_name)
             if isinstance(preproc_fun_name, str):
-                # get preprocessing function associated with a specific model
+                # get preprocessing function for a specific model
                 preproc_fun = self.get_preproc_fun(preproc_fun_name)
                 # different models take differently sized inputs. this has to be accounted for.
-                resize_dim = self.model.layers[0].input_shape[0][-2] # -2 and -3 are H and W dims.
+                resize_dim = self.model.layers[0].input_shape[0][-2] # -2 and -3 are the H and W channel dims.
                 self.preprocess = tf.keras.Sequential([Lambda(preproc_fun), tf.keras.layers.experimental.preprocessing.Resizing(resize_dim, resize_dim)])
         else:
             raise ValueError(

--- a/thingsvision/core/extraction/tensorflow.py
+++ b/thingsvision/core/extraction/tensorflow.py
@@ -88,7 +88,7 @@ class TensorFlowExtractor(BaseExtractor):
         apply_center_crop: bool = True,
     ) -> Any:
         resize_dim = crop_dim
-        composes = [layers.experimental.preprocessing.Resizing(resize_dim, resize_dim)]
+        composes = [layers.experimental.preprocessing.Resizing(resize_dim, resize_dim), layers.experimental.preprocessing.Rescaling(1./255.)]
         if apply_center_crop:
             pass
             # TODO: fix center crop problem with Keras


### PR DESCRIPTION
Hi,

This pull request fixes the following:

## Harmonizer (and Generic `tf`) Models

The default `tf` preprocessing now rescales the RGBs between 0, and 1. As you can see [here](https://github.com/candemircan/harmonizer_thingsvision_check/blob/main/thingsvision_tf_keras_check.ipynb), now we get identical results from `thingsvision` and when using the harmonized models directly.

Note that this also applies the same scaling to **any** `tf` model that is manually turned into an extractor, and any `tf` model that does not specify a preprocessing function.

## `tf.keras` pretrained model fixes

Before these commits, always the same preprocessing was applied to the pretrained `tf.keras.applications` models. This yielded silent but catastrophic errors, as unfortunately, the pretrained models differ in their preprocessing in non-systematic ways. This is now fixed. Again, using models via `thingsvision` and directly yielded the same results [here](https://github.com/candemircan/harmonizer_thingsvision_check/blob/main/thingsvision_tf_keras_check.ipynb).

Getting the correct preprocessing function is a bit tricky, as it is done via different modules and functions and not through arguments (e.g., `tf.keras.applications.efficientnet_v2.preprocess_input`). Additionally, the preprocessing module names differ from the model names in subtle ways. I tried to resolve this using regular expressions, and it seems to work for the current models. If there is no regexp match, currently we raise a warning saying no preprocessing function could be found and that the user should be careful, and we revert to default preprocessing described in the previous section. If new pretrained models get added, its name needs to be added to the function. This is not ideal, but I  couldn't find a better, more generic way.


Additionally, different keras models have different input sizes, and this needs to be accounted for. Now it should be sorted.

## testing

I did all the testing in a separate repo [here](https://github.com/candemircan/harmonizer_thingsvision_check/blob/main/thingsvision_tf_keras_check.ipynb), where I'd also reproduced some of these issues. I know you have a `tests` folder here. I couldn't quite wrap my head around how to do some of the simple tests I did there. For example, I see that you have a `create_test_images` function that you call, but I don't see where these images actually get used in the tests. Instead, I think some manually created values are being passed through the models? Either way, it should be straightforward to add the tests I did into your test suite for someone who understands the structure.

---

Sorry for closing and reopening an issue. Had to create a new branch and delete the old one. 