### PR TITLE
Overwrite option of vision_cfg for OpenClip custom models and OpenClip version update

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,14 +12,14 @@ jobs:
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.9'
+      PYTHON: '3.10'
 
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: 3.9
+        python-version: "3.10"
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10.x"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ keras-cv-attention-models>=1.3.5
 matplotlib
 numba
 numpy<=1.26.4 
-open_clip_torch==2.24.*
+open_clip_torch==3.*
 pandas
 regex
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,21 +3,22 @@ h5py
 keras-cv-attention-models>=1.3.5
 matplotlib
 numba
-numpy<=1.26.4 
+numpy<2
 open_clip_torch==3.*
 pandas
 regex
 scikit-image
 scikit-learn
 scipy
-tensorflow==2.9.* ; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.9.* ; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow<2.16
 timm
 torch>=2.0.0
 torchvision==0.15.2
 torchtyping
 tqdm
-dreamsim==0.1.3
+pytest
 git+https://github.com/openai/CLIP.git
+dreamsim==0.1.3
+vit-keras==0.1.2
 git+https://github.com/serre-lab/Harmonization.git
 transformers==4.40.1

--- a/setup.py
+++ b/setup.py
@@ -11,24 +11,28 @@ requirements = [
     "h5py",
     "matplotlib",
     "numba",
-    "numpy",
-    "open_clip_torch==2.24.*",
+    "numpy<2",
+    "open_clip_torch==3.*",
     "pandas",
     "regex",
     "scikit-image",
     "scikit-learn",
     "scipy",
-    "tensorflow==2.9.* ; sys_platform != 'darwin' or platform_machine != 'arm64'",
-    "tensorflow-macos==2.9.* ; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    # "tensorflow==2.9.* ; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    # "tensorflow-macos==2.9.* ; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "tensorflow<2.16",
     "timm",
     "torch>=2.0.0",
     "torchvision==0.15.2",
     "torchtyping",
     "tqdm",
-    "CLIP",
-    "transformers==4.40.1"
-    # 'CLIP @ git+ssh://git@github.com/openai/CLIP@v1.0#egg=CLIP' # TODO: see issue #111
-]
+    "transformers==4.40.1",
+    "pytest",
+    "CLIP @ git+https://github.com/openai/CLIP.git",
+    "dreamsim==0.1.3",
+    "Harmonization @ git+https://github.com/serre-lab/Harmonization.git",
+    "vit-keras==0.1.2",
+    ]
 
 setuptools.setup(
     name="thingsvision",
@@ -44,13 +48,13 @@ setuptools.setup(
     install_requires=requirements,
     keywords="feature extraction",
     classifiers=[
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
         "Natural Language :: English",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     entry_points={"console_scripts": ["thingsvision = thingsvision.thingsvision:main"]},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     dependency_links=[
         "git+https://github.com/openai/CLIP.git",
     ],

--- a/tests/extractor/extraction/test_pretrained_model.py
+++ b/tests/extractor/extraction/test_pretrained_model.py
@@ -1,7 +1,7 @@
 import shutil
 import unittest
 import os
-
+import warnings
 import numpy as np
 import tests.helper as helper
 from thingsvision.utils.checkpointing import get_torch_home
@@ -12,6 +12,12 @@ Array = np.ndarray
 class ExtractionPretrainedTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        warnings.filterwarnings(
+            "ignore",
+            message="Call to deprecated create function FieldDescriptor().*",
+            category=DeprecationWarning,
+            module="tensorflow.*",
+        )
         helper.create_test_images()
 
     def test_extraction_pretrained_models(self):
@@ -21,7 +27,7 @@ class ExtractionPretrainedTestCase(unittest.TestCase):
             dataset,
             batches,
             module_names,
-            model_name
+            model_name,
         ) in helper.iterate_through_all_model_combinations():
             num_objects = len(dataset)
 
@@ -44,9 +50,15 @@ class ExtractionPretrainedTestCase(unittest.TestCase):
                 if extractor.get_backend() == "pt":
                     if model_name in helper.ALIGNED_MODELS:
                         if module_name == helper.ALIGNED_MODELS[model_name]:
-                            print(f"\nAligning representations extracted from layer: {module_name} of model: {model_name}")
-                            aligned_features = extractor.align(features=features, module_name=module_name)
-                            print(f"Successfully aligned the representation space of model: {model_name}\n")
+                            print(
+                                f"\nAligning representations extracted from layer: {module_name} of model: {model_name}"
+                            )
+                            aligned_features = extractor.align(
+                                features=features, module_name=module_name
+                            )
+                            print(
+                                f"Successfully aligned the representation space of model: {model_name}\n"
+                            )
                             self.assertTrue(isinstance(aligned_features, Array))
                             self.assertEqual(aligned_features.shape, features.shape)
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -87,20 +87,58 @@ MODEL_AND_MODULE_NAMES = {
         "clip": True,
         "kwargs": {"variant": "ViT-L-14", "dataset": "laion400m_e32"},
     },
+    "OpenCLIP_vitl14_custom_vision_cfg_avg_pool": {
+        "model_name": "OpenCLIP",
+        "modules": ["visual"],
+        "pretrained": True,
+        "source": "custom",
+        "clip": True,
+        "kwargs": {
+            "variant": "ViT-L-14",
+            "dataset": "laion400m_e32",
+            "vision_cfg": {
+                "image_size": 224,
+                "layers": 24,
+                "width": 1024,
+                "patch_size": 14,
+                "pool_type": "none",
+            },
+            "token_extraction": "avg_pool",
+        },
+    },
+    "OpenCLIP_vitl14_custom_vision_cfg_cls_token": {
+        "model_name": "OpenCLIP",
+        "modules": ["visual"],
+        "pretrained": True,
+        "source": "custom",
+        "clip": True,
+        "kwargs": {
+            "variant": "ViT-L-14",
+            "dataset": "laion400m_e32",
+            "vision_cfg": {
+                "image_size": 224,
+                "layers": 24,
+                "width": 1024,
+                "patch_size": 14,
+                "pool_type": "none",
+            },
+            "token_extraction": "cls_token",
+        },
+    },
     # Timm models
-    # "vit_base_patch16_224": {
-    #    "model_name": "vit_base_patch16_224",
-    #    "modules": ["encoder.ln"],
-    #    "pretrained": True,
-    #    "source": "timm",
-    #    "kwargs": {"token_extraction": "avg_pool"},
-    # },
-    # "mixnet_l": {
-    #    "model_name": "mixnet_l",
-    #    "modules": ["conv_head"],
-    #    "pretrained": True,
-    #    "source": "timm",
-    # },
+    "vit_base_patch16_224": {
+        "model_name": "vit_base_patch16_224",
+        "modules": ["norm"],
+        "pretrained": True,
+        "source": "timm",
+        "kwargs": {"token_extraction": "avg_pool"},
+    },
+    "mixnet_l": {
+        "model_name": "mixnet_l",
+        "modules": ["conv_head"],
+        "pretrained": True,
+        "source": "timm",
+    },
     # Keras models
     "VGG16_keras": {
         "model_name": "VGG16",
@@ -172,7 +210,7 @@ MODEL_AND_MODULE_NAMES = {
         "modules": ["norm"],
         "pretrained": True,
         "source": "ssl",
-        "kwargs": {"extract_cls_token": True},
+        "kwargs": {"token_extraction": "cls_token"},
     },
     "mae-vit-base-p16": {
         "model_name": "mae-vit-base-p16",
@@ -218,7 +256,7 @@ MODEL_AND_MODULE_NAMES = {
         "kwargs": {"variant": "vit_b"},
         # model input size is large, therefore reduce test case on cpu
         "batch_size": 1,
-        "num_samples": 1
+        "num_samples": 1,
     },
     "kakobrain_align_model": {
         "model_name": "Kakaobrain_Align",
@@ -343,8 +381,12 @@ def iterate_through_all_model_combinations():
 
 
 def create_extractor_and_dataloader(
-        model_name: str, pretrained: bool, source: str, kwargs: dict = {},
-        batch_size: int = BATCH_SIZE, num_samples: int = NUM_SAMPLES
+    model_name: str,
+    pretrained: bool,
+    source: str,
+    kwargs: dict = {},
+    batch_size: int = BATCH_SIZE,
+    num_samples: int = NUM_SAMPLES,
 ):
     """Iterate through models and create model, dataset and data loader."""
     extractor = get_extractor(
@@ -361,7 +403,9 @@ def create_extractor_and_dataloader(
         transforms=extractor.get_transformations(),
     )
     if num_samples > NUM_SAMPLES:
-        raise ValueError("\nNumber of samples in test case cannot be larger than the default value, only smaller.\n")
+        raise ValueError(
+            "\nNumber of samples in test case cannot be larger than the default value, only smaller.\n"
+        )
     elif num_samples < NUM_SAMPLES:
         dataset = Subset(dataset, np.arange(num_samples))
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -45,7 +45,7 @@ class RSATestCase(unittest.TestCase):
 
         for rdm_i, rdm_j in zip(rdms[:-1], rdms[1:]):
             corr = correlate_rdms(rdm_i, rdm_j)
-            self.assertTrue(isinstance(corr, float))
+            self.assertTrue(isinstance(corr, (float, np.floating)))
             self.assertTrue(corr > float(-1) and corr < float(1))
 
 

--- a/thingsvision/core/extraction/torch.py
+++ b/thingsvision/core/extraction/torch.py
@@ -122,6 +122,7 @@ class PyTorchExtractor(BaseExtractor):
         """Extract representations from a batch of images."""
         # move mini-batch to current device
         batch = batch.to(self.device)
+        batch_size = batch.shape[0]
         _ = self.forward(batch)
         act = self.activations[module_name]
         if len(act.shape) > 2:
@@ -144,6 +145,11 @@ class PyTorchExtractor(BaseExtractor):
                     act = self.flatten_acts(act, batch, module_name)
                 else:
                     act = self.flatten_acts(act)
+        if act.shape[0] != batch_size:
+            raise ValueError(
+                f"The number of extracted features ({act.shape=}) does not match the batch size ({batch.shape=}). "
+                "Please check the model, the module name, and the model parameters ..."
+            )
         if act.is_cuda or act.get_device() >= 0:
             torch.cuda.empty_cache()
             act = act.cpu()

--- a/thingsvision/custom_models/openclip.py
+++ b/thingsvision/custom_models/openclip.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Any
 
 import open_clip
@@ -11,6 +12,7 @@ class OpenCLIP(Custom):
         self.backend = "pt"
         self.dataset = parameters.get("dataset", "laion400m_e32")
         self.variant = parameters.get("variant", "ViT-B-32-quickgelu")
+        self.vision_cfg = parameters.get("vision_cfg", None)
 
     def check_available_variants_and_datasets(self):
         found = False
@@ -25,7 +27,13 @@ class OpenCLIP(Custom):
 
     def create_model(self) -> Any:
         self.check_available_variants_and_datasets()
-        model, _, preprocess = open_clip.create_model_and_transforms(
-            self.variant, pretrained=self.dataset
+        fun = partial(
+            open_clip.create_model_and_transforms,
+            model_name=self.variant,
+            pretrained=self.dataset,
         )
+        if self.vision_cfg:
+            fun = partial(fun, vision_cfg=self.vision_cfg)
+
+        model, _, preprocess = fun()
         return model, preprocess

--- a/thingsvision/custom_models/openclip.py
+++ b/thingsvision/custom_models/openclip.py
@@ -27,13 +27,12 @@ class OpenCLIP(Custom):
 
     def create_model(self) -> Any:
         self.check_available_variants_and_datasets()
-        fun = partial(
-            open_clip.create_model_and_transforms,
-            model_name=self.variant,
-            pretrained=self.dataset,
-        )
+        kwargs = {
+            "model_name": self.variant,
+            "pretrained": self.dataset,
+        }
         if self.vision_cfg:
-            fun = partial(fun, vision_cfg=self.vision_cfg)
+            kwargs["vision_cfg"] = self.vision_cfg
 
-        model, _, preprocess = fun()
+        model, _, preprocess = open_clip.create_model_and_transforms(**kwargs)
         return model, preprocess


### PR DESCRIPTION
### Enable custom pooling methods for CLIP vision encoders
Added support for manually specifying vision configuration to control pooling behavior in transformer-based image encoders.

**Previous behavior:** Pooling method defaulted to model-specific config, falling back to class token pooling when unavailable.

**New behavior:** Users can now pass a custom vision config with configurable `pool_type`/`timm_pool` parameters to override default pooling methods.

### Upgrade open_clip_pytorch dependency
Updated to newer version of open_clip_pytorch to resolve dimension ordering issues.

**Issue resolved:** Previous versions incorrectly swapped batch and sequence dimensions in transformer-based image encoders, complicating intermediate layer representation extraction. The updated version makes this dimension swapping optional, providing more consistent tensor layouts.