### PR TITLE
Fixes multi-module feature extraction bugs and handling of Pytorch dataloaders, which return image-target pairs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ torch>=2.0.0
 torchvision==0.15.2
 torchtyping
 tqdm
+accelerate<1.10.0
 transformers==4.40.1
 pytest
 git+https://github.com/openai/CLIP.git

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requirements = [
     "torchvision==0.15.2",
     "torchtyping",
     "tqdm",
+    "accelerate<1.10.0",
     "transformers==4.40.1",
     "pytest",
     ]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,7 +12,7 @@ from tensorflow.keras.models import Sequential
 
 from thingsvision import get_extractor
 from thingsvision.utils.data import DataLoader, ImageDataset
-from torch.utils.data import Subset
+from torch.utils.data import Subset, Dataset
 
 DATA_PATH = "./data"
 TEST_PATH = "./test_images"
@@ -359,6 +359,35 @@ class SimpleDataset(object):
 
     def __len__(self) -> int:
         return len(self.values)
+
+
+class MockImageDataset(Dataset):
+    """Mock dataset that returns (image, label) tuples"""
+
+    def __init__(self, size=10):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        image = torch.randn(3, 32, 32)
+        label = torch.tensor(idx % 5)
+        return image, label
+
+
+class MockImageOnlyDataset(Dataset):
+    """Mock dataset that returns only images (not tuples)"""
+
+    def __init__(self, size=10):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        # Return only image tensor (no tuple)
+        return torch.randn(3, 32, 32)
 
 
 def iterate_through_all_model_combinations():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -44,7 +44,7 @@ class FeaturesTestCase(unittest.TestCase):
             flatten_acts=False,
         )
         return features
-    
+
     def get_multi_features(self):
         model_name = "vgg16_bn"
         extractor, _, batches = helper.create_extractor_and_dataloader(
@@ -102,7 +102,7 @@ class FeaturesTestCase(unittest.TestCase):
             )
 
             self.check_file_exists("features", format, False)
-    
+
     def test_storing_multi(self):
         features = self.get_multi_features()
         for _, feature in features.items():
@@ -114,6 +114,14 @@ class FeaturesTestCase(unittest.TestCase):
                     file_format=format,
                 )
                 self.check_file_exists(f"features", format, False)
+
+    def test_extract_multi(self):
+        features = self.get_multi_features()
+        row_counts = [feature.shape[0] for feature in features.values()]
+        self.assertTrue(
+            all(count == row_counts[0] for count in row_counts),
+            "Not all features have the same number of rows!",
+        )
 
     def test_splitting_2d(self):
         n_splits = 3
@@ -154,7 +162,7 @@ class FeaturesTestCase(unittest.TestCase):
                 file_format="txt",
                 n_splits=n_splits,
             )
-    
+
     def test_splitting_multi(self):
         n_splits = 3
         features = self.get_multi_features()

--- a/thingsvision/core/extraction/base.py
+++ b/thingsvision/core/extraction/base.py
@@ -351,7 +351,7 @@ class BaseExtractor(metaclass=abc.ABCMeta):
                         f"...Features for module '{module_name}' were saved to {features_file}."
                     )
                     for file in feature_file_names[module_name]:
-                        os.remove(os.path.join(output_dir, file))
+                        os.remove(file)
 
             print(f"...Features were saved to {output_dir}.")
             return None


### PR DESCRIPTION
### This PR fixes the following bugs in the feature extraction pipeline `extract_features` 

- `BaseExtractor.extract_features`:
    - When storing intermediate results previously, we reset `features=defaultdict(list)`. This, unfortunately, deletes the intermediate results of other modules. Therefore changed to `features[module_name]=[]` 
    - Paths need to be created before trying to store data: if `module/feature` does not exist, then an error is thrown. 
    - We store intermediate file names. When `save_in_one_file=True`, `output_dir` is prepended again. Which incorrect.
- PyTorchExtractor calls `super().extract_features` --> need to add `file_name_suffix` and `save_in_one_file` as arguments to be able to pass it to the parent.

### NEW: Dataloader modifier
PR adds a context manager for PyTorch feature extraction. Assumes that a dataloader either returns an image or a tuple of (image, *args) or a list of (image, *args). If the dataloader returns a tuple of (image, *args) or a list of (image, *args), it will return only the images. The class does not modify otherwise (e.g., specialized dataloaders).